### PR TITLE
fix text not rendering correctly when not using FRUSTRATIO_2

### DIFF
--- a/include/config/config_graphics.h
+++ b/include/config/config_graphics.h
@@ -150,4 +150,4 @@
  * Can improve performance in some circumstances, though it can also cause large tris to warp if cut off from the camera.
  * Only use this if you can test the difference of your hack with and without this change on console.
  */
-#define USE_FRUSTRATIO2
+// #define USE_FRUSTRATIO2

--- a/include/config/config_graphics.h
+++ b/include/config/config_graphics.h
@@ -150,4 +150,4 @@
  * Can improve performance in some circumstances, though it can also cause large tris to warp if cut off from the camera.
  * Only use this if you can test the difference of your hack with and without this change on console.
  */
-// #define USE_FRUSTRATIO2
+#define USE_FRUSTRATIO2

--- a/src/game/axotext.c
+++ b/src/game/axotext.c
@@ -147,6 +147,9 @@ void axotext_setup(void) {
     );
     gSPClearGeometryMode(AXOTEXT_GDL_HEAD++, G_ZBUFFER);
     gDPSetRenderMode(AXOTEXT_GDL_HEAD++, G_RM_AA_XLU_SURF, G_RM_AA_XLU_SURF2);
+#ifndef USE_FRUSTRATIO2 // HackerSM64 specific define, idk if it should be changed to something different or if this check is even needed that much
+    gSPClipRatio(AXOTEXT_GDL_HEAD++, FRUSTRATIO_2);
+#endif
 }
 
 void axotext_revert(void) {
@@ -162,6 +165,9 @@ void axotext_revert(void) {
         0, 0, 0, SHADE, 0, 0, 0, ENVIRONMENT
     );
     gSPTexture(AXOTEXT_GDL_HEAD++, 65535, 65535, 0, 0, 0);
+#ifndef USE_FRUSTRATIO2
+    gSPClipRatio(AXOTEXT_GDL_HEAD++, FRUSTRATIO_1);
+#endif
 }
 
 /**

--- a/src/game/axotext.c
+++ b/src/game/axotext.c
@@ -147,9 +147,7 @@ void axotext_setup(void) {
     );
     gSPClearGeometryMode(AXOTEXT_GDL_HEAD++, G_ZBUFFER);
     gDPSetRenderMode(AXOTEXT_GDL_HEAD++, G_RM_AA_XLU_SURF, G_RM_AA_XLU_SURF2);
-#ifndef USE_FRUSTRATIO2 // HackerSM64 specific define, idk if it should be changed to something different or if this check is even needed that much
     gSPClipRatio(AXOTEXT_GDL_HEAD++, FRUSTRATIO_2);
-#endif
 }
 
 void axotext_revert(void) {
@@ -165,9 +163,6 @@ void axotext_revert(void) {
         0, 0, 0, SHADE, 0, 0, 0, ENVIRONMENT
     );
     gSPTexture(AXOTEXT_GDL_HEAD++, 65535, 65535, 0, 0, 0);
-#ifndef USE_FRUSTRATIO2
-    gSPClipRatio(AXOTEXT_GDL_HEAD++, FRUSTRATIO_1);
-#endif
 }
 
 /**


### PR DESCRIPTION
Fixes the text rendering like this when `USE_FRUSTRATIO_2` is not set in `include/config/config_graphics.h`
![2023-10-03_19-47](https://github.com/axollyon/axotext/assets/14117628/99d88ab0-d2cc-4be5-8ba8-2a0924d7238d)