### PR TITLE
Fix char buffer not getting terminated when adding new char

### DIFF
--- a/src/game/axotext.c
+++ b/src/game/axotext.c
@@ -61,6 +61,7 @@ void axotext_add_char(unsigned char c, f32 x, f32 y, AxotextFont *font, f32 w, f
                 // Character with the same texture has not already been added:
                 // Add the new character to the end of the head array
                 axotextBufferHeads[i] = &axotextBuffer[axotextBufferIndex];
+                axotextBuffer[axotextBufferIndex].next = NULL;
                 axotextBufferHeadsIndex++;
 
                 charPlaced = TRUE;


### PR DESCRIPTION
If you call axotext_print on one frame and again on the next frame with a string that has more unique chars than the previous string, it ends up drawing random garbage to the screen due to the pointer to the next char at the end never being set to null.

You can replicate this bug with this code, placed in hud.c before axotext_render:
```c
static u8 asdf = 0;
if(asdf++ == 0) {
    axotext_print(160, 40, &params, -1, "aaaaaaaaaaaaaaaaaaa");
} else {
    axotext_print(160, 40, &params, -1, "qwertyuiopasdf!?><@");
}
```

Without the fix:
![2024-03-21_15-04_1](https://github.com/axollyon/axotext/assets/14117628/c754860b-af88-4608-aa89-4262b75ac420)

With the fix:
![2024-03-21_15-04](https://github.com/axollyon/axotext/assets/14117628/bebd9f8c-6913-4caa-b3dc-ce46c9a7b3a1)